### PR TITLE
Add queue wait time metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ make
 | clamav_pool_max_threads | Maximum number of threads in the pool. | index, primary
 | clamav_pool_idle_timeout_threads | Number of idle timeout threads in the pool. | index, primary
 | clamav_pool_queue_length | Number of items in the pool queue. | index, primary
+| clamav_pool_queue_min_wait_sec | Minimum time a currently queued item has been waiting. | index, primary
+| clamav_pool_queue_max_wait_sec | Maximum time a currently queued item has been waiting. | index, primary
+| clamav_pool_queue_avg_wait_sec | Average time that currently queued items have been waiting. | index, primary
 | clamav_memory_heap_bytes | Number of bytes allocated on the heap. |
 | clamav_memory_mmap_bytes | Number of bytes currently allocated using mmap. |
 | clamav_memory_used_bytes | Number of bytes used by in-use allocations. |

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -36,7 +36,12 @@ func TestExporter_Collect(t *testing.T) {
 						Max:         newInt64(125),
 						IdleTimeout: newInt64(126),
 					},
-					QueueLength: 127,
+					Queue: queue{
+						Length:  127,
+						MinWait: 0.131,
+						MaxWait: 0.132,
+						AvgWait: 0.133,
+					},
 				},
 			},
 			Memory: memory{

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -12,10 +12,17 @@ type db struct {
 }
 
 type pool struct {
-	State       string
-	Primary     bool
-	Threads     threads
-	QueueLength int64
+	State   string
+	Primary bool
+	Threads threads
+	Queue   queue
+}
+
+type queue struct {
+	Length  int64
+	MinWait float64
+	MaxWait float64
+	AvgWait float64
 }
 
 type threads struct {

--- a/exporter/testdata/3-metrics.txt
+++ b/exporter/testdata/3-metrics.txt
@@ -34,9 +34,18 @@ clamav_pool_max_threads{index="0",primary="1"} 12
 # HELP clamav_pool_state State of the thread pool.
 # TYPE clamav_pool_state gauge
 clamav_pool_state{index="0",primary="1"} 1
+# HELP clamav_pool_queue_avg_wait_sec Average wait time in the pool queue.
+# TYPE clamav_pool_queue_avg_wait_sec gauge
+clamav_pool_queue_avg_wait_sec{index="0",primary="1"} 0
 # HELP clamav_pool_queue_length Number of items in the pool queue.
 # TYPE clamav_pool_queue_length gauge
 clamav_pool_queue_length{index="0",primary="1"} 0
+# HELP clamav_pool_queue_max_wait_sec Maximum wait time in the pool queue.
+# TYPE clamav_pool_queue_max_wait_sec gauge
+clamav_pool_queue_max_wait_sec{index="0",primary="1"} 0
+# HELP clamav_pool_queue_min_wait_sec Minimum wait time in the pool queue.
+# TYPE clamav_pool_queue_min_wait_sec gauge
+clamav_pool_queue_min_wait_sec{index="0",primary="1"} 0
 # HELP clamav_up Was the last scrape successful.
 # TYPE clamav_up gauge
 clamav_up 1

--- a/exporter/testdata/metrics.txt
+++ b/exporter/testdata/metrics.txt
@@ -28,9 +28,18 @@ clamav_pool_max_threads{index="0",primary="1"} 125
 # HELP clamav_pool_state State of the thread pool.
 # TYPE clamav_pool_state gauge
 clamav_pool_state{index="0",primary="1"} 2
+# HELP clamav_pool_queue_avg_wait_sec Average wait time in the pool queue.
+# TYPE clamav_pool_queue_avg_wait_sec gauge
+clamav_pool_queue_avg_wait_sec{index="0",primary="1"} 0.133
 # HELP clamav_pool_queue_length Number of items in the pool queue.
 # TYPE clamav_pool_queue_length gauge
 clamav_pool_queue_length{index="0",primary="1"} 127
+# HELP clamav_pool_queue_max_wait_sec Maximum wait time in the pool queue.
+# TYPE clamav_pool_queue_max_wait_sec gauge
+clamav_pool_queue_max_wait_sec{index="0",primary="1"} 0.132
+# HELP clamav_pool_queue_min_wait_sec Minimum wait time in the pool queue.
+# TYPE clamav_pool_queue_min_wait_sec gauge
+clamav_pool_queue_min_wait_sec{index="0",primary="1"} 0.131
 # HELP clamav_up Was the last scrape successful.
 # TYPE clamav_up gauge
 clamav_up 1


### PR DESCRIPTION
When the queue is non-empty, ClamAV's STAT command provides the following information about the queue:

    QUEUE: 10 items min_wait: 0.095934 max_wait: 28.350554 avg_wait: 9.622872

This commit adds metrics for wait times to this Prometheus exporter.

When the queue is empty, these metrics are not shown in ClamAV's STAT command output but are implicitly 0.